### PR TITLE
feat(blazwitcher): sparkles  open a modal when current tab is in fullscreen state

### DIFF
--- a/.changeset/sweet-coats-remain.md
+++ b/.changeset/sweet-coats-remain.md
@@ -1,0 +1,5 @@
+---
+"blazwitcher": patch
+---
+
+support open a modal when current tab is in fullscreen state

--- a/package.json
+++ b/package.json
@@ -42,10 +42,7 @@
 		}
 	},
 	"manifest": {
-		"host_permissions": [
-			"https://*/*",
-			"http://*/*"
-		],
+		"host_permissions": ["https://*/*", "http://*/*"],
 		"commands": {
 			"_execute_action": {
 				"suggested_key": {
@@ -58,6 +55,12 @@
 		"action": {
 			"default_title": "Blazwitcher"
 		},
+		"web_accessible_resources": [
+			{
+				"resources": ["sidepanel.html"],
+				"matches": ["<all_urls>"]
+			}
+		],
 		"permissions": [
 			"tabs",
 			"tabGroups",
@@ -68,7 +71,8 @@
 			"favicon",
 			"system.display",
 			"sidePanel",
-			"contextMenus"
+			"contextMenus",
+			"scripting"
 		],
 		"offline_enabled": true
 	}

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -72,6 +72,8 @@ export const closeCurrentWindowAndClearStorage = async () => {
 			await chrome.windows.remove(selfWindowId)
 		} catch (error) {}
 	}
+	// 和父 window 通信，关闭全屏状态下的 modal
+	window.parent.postMessage({ type: 'close' }, '*')
 }
 
 export const activeTab = async (item: ListItemType<ItemType.Tab>) => {


### PR DESCRIPTION
No longer open a new window when current tab is in fullscreen state which's very poor experience. Now inject a script to open a modal in active tab.  Close #24 
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d3b55b1c-697e-4b76-984e-018c0e3441f0">
