### PR TITLE
feat(blazwitcher-extension): :sparkles: Add open-in-new-tab shortcut

### DIFF
--- a/packages/blazwitcher-extension/i18n/lang.ts
+++ b/packages/blazwitcher-extension/i18n/lang.ts
@@ -206,6 +206,10 @@ export const lang = {
 		[LanguageType.zh]: '打开当前标签',
 		[LanguageType.en]: 'Open current tab',
 	},
+	openInNewTab: {
+		[LanguageType.zh]: '在新标签页中打开',
+		[LanguageType.en]: 'Open in new tab',
+	},
 	pin: {
 		[LanguageType.zh]: 'Pin/Unpin 标签页',
 		[LanguageType.en]: 'Pin/Unpin tab',

--- a/packages/blazwitcher-extension/shared/types.ts
+++ b/packages/blazwitcher-extension/shared/types.ts
@@ -59,18 +59,20 @@ export interface ListItemType<T extends ItemType = ItemType> {
 }
 
 export enum OperationItemPropertyTypes {
-	start = 'start',
-	open = 'open',
-	switch = 'switch',
-	pin = 'pin',
-	query = 'query',
-	delete = 'delete',
-	close = 'close',
-}
+		start = 'start',
+		open = 'open',
+		openInNewTab = 'openInNewTab',
+		switch = 'switch',
+		pin = 'pin',
+		query = 'query',
+		delete = 'delete',
+		close = 'close',
+	}
 
 export const OperationItemTitleMap: Record<string, TranslationKeys> = {
 	[OperationItemPropertyTypes.open]: 'openCurrentTab',
 	[OperationItemPropertyTypes.switch]: 'openCurrentTab',
+	[OperationItemPropertyTypes.openInNewTab]: 'openInNewTab',
 	[OperationItemPropertyTypes.pin]: 'pin',
 	[OperationItemPropertyTypes.query]: 'query',
 	[OperationItemPropertyTypes.delete]: 'deleteFromHistory',

--- a/packages/blazwitcher-extension/sidepanel/atom/shortcutAtom.ts
+++ b/packages/blazwitcher-extension/sidepanel/atom/shortcutAtom.ts
@@ -22,6 +22,11 @@ const defaultShortcutConfigs: Shortcut[] = [
 		shortcut: 'Enter',
 	},
 	{
+		id: OperationItemPropertyTypes.openInNewTab,
+		action: 'openInNewTab',
+		shortcut: 'Shift + ↵',
+	},
+	{
 		id: OperationItemPropertyTypes.close,
 		action: 'closeTab',
 		shortcut: 'Ctrl + Shift + W',

--- a/packages/blazwitcher-extension/sidepanel/hooks/useKeyboardListen.ts
+++ b/packages/blazwitcher-extension/sidepanel/hooks/useKeyboardListen.ts
@@ -27,7 +27,6 @@ export const useKeyboardListen = (list: ListItemType[], activeIndex: number) => 
 
 			const orderedKeys = standardizeKeyOrder(keys)
 			const pressedShortcut = orderedKeys.join(' + ')
-
 			// 查找匹配的快捷键
 			const matchedShortcut = shortcuts.find((s) => s.shortcut.toLowerCase() === pressedShortcut.toLowerCase())
 			if (matchedShortcut) {

--- a/packages/blazwitcher-extension/sidepanel/hooks/useOperations.ts
+++ b/packages/blazwitcher-extension/sidepanel/hooks/useOperations.ts
@@ -1,7 +1,15 @@
 import { useAtom, useAtomValue } from 'jotai'
 import { useCallback } from 'react'
 import { type ListItemType, OperationItemPropertyTypes } from '~shared/types'
-import { deleteItem, handleItemClick, isBookmarkItem, isHistoryItem, isTabItem, queryInNewTab } from '~shared/utils'
+import {
+	createTabWithUrl,
+	deleteItem,
+	handleItemClick,
+	isBookmarkItem,
+	isHistoryItem,
+	isTabItem,
+	queryInNewTab,
+} from '~shared/utils'
 import { i18nAtom, originalListAtom } from '~sidepanel/atom'
 
 export const useListOperations = () => {
@@ -40,6 +48,9 @@ export const useListOperations = () => {
 			case OperationItemPropertyTypes.switch:
 			case OperationItemPropertyTypes.open:
 				handleItemClick(item)
+				break
+			case OperationItemPropertyTypes.openInNewTab:
+				await createTabWithUrl(item.data.url)
 				break
 			case OperationItemPropertyTypes.close:
 				isTabItem(item) &&

--- a/packages/blazwitcher-extension/sidepanel/list.tsx
+++ b/packages/blazwitcher-extension/sidepanel/list.tsx
@@ -142,9 +142,6 @@ export default function List({ list, RenderItem, handleItemClick }: ListProps) {
 	// 累积的偏移量，用于在快速连续按键时收集所有偏移量，通过防抖机制批量处理，避免频繁更新 activeIndex 造成性能问题
 	const accumulatedOffset = useRef(0)
 
-	// listen shortcut
-	useKeyboardListen(list, activeIndex)
-
 	useEffect(() => {
 		// reset active index to first non-divide item
 		const firstValidIndex = list.findIndex((item) => !isDivideItem(item))
@@ -223,6 +220,11 @@ export default function List({ list, RenderItem, handleItemClick }: ListProps) {
 
 	const keydownHandler = useCallback(
 		(event: KeyboardEvent) => {
+			// 如果 Enter 键配合修饰键（如 Shift），走 useKeyboardListen 的监听
+			if (event.code === 'Enter' && (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey)) {
+				return
+			}
+
 			const keyActions: { [key: string]: () => void } = {
 				ArrowUp: () => keyActionsChangeIndex(-1),
 				Tab: () => keyActionsChangeIndex(1),
@@ -239,6 +241,9 @@ export default function List({ list, RenderItem, handleItemClick }: ListProps) {
 		[handleEnterEvent, keyActionsChangeIndex]
 	)
 
+	// listen shortcut event (注意键位可能有冲突，这边监听了两个keydown事件)
+	useKeyboardListen(list, activeIndex)
+	// listen default event
 	useEffect(() => {
 		// only listen to keydown when not in composition（type chinese）
 		!isComposition && window.addEventListener('keydown', keydownHandler)


### PR DESCRIPTION
close #94 
<img width="1520" height="950" alt="image" src="https://github.com/user-attachments/assets/89d13f17-9700-4d1f-90d6-8ff2a40afdc0" />
快捷键支持在新窗口打开标签页（默认快捷键： "Shift + ↵"，支持修改快捷键）
Add shortcut key support for opening tabs in a new window (default: "Shift + Enter", customizable)
