### PR TITLE
feat(font-select): ✨ add UI font selection function

### DIFF
--- a/.changeset/bright-cats-open.md
+++ b/.changeset/bright-cats-open.md
@@ -1,0 +1,6 @@
+---
+"blazwitcher": minor
+---
+
+feat: add font family setting in appearance panel with system font options and persisted preference.
+feat: 在外观设置面板新增字体选择，支持系统字体选项并持久化用户偏好。

--- a/packages/blazwitcher-extension/i18n/lang.ts
+++ b/packages/blazwitcher-extension/i18n/lang.ts
@@ -172,6 +172,18 @@ export const lang = {
 		[LanguageType.zh]: '语言',
 		[LanguageType.en]: 'Language',
 	},
+	fontFamily: {
+		[LanguageType.zh]: '字体',
+		[LanguageType.en]: 'Font Family',
+	},
+	fontDefault: {
+		[LanguageType.zh]: '软件默认',
+		[LanguageType.en]: 'App Default',
+	},
+	fontSystem: {
+		[LanguageType.zh]: '系统默认',
+		[LanguageType.en]: 'System Default',
+	},
 	// debug settings
 	debug: {
 		[LanguageType.zh]: '调试',

--- a/packages/blazwitcher-extension/package.json
+++ b/packages/blazwitcher-extension/package.json
@@ -86,7 +86,8 @@
 			"system.display",
 			"sidePanel",
 			"contextMenus",
-			"scripting"
+			"scripting",
+			"fontSettings"
 		],
 		"offline_enabled": true
 	}

--- a/packages/blazwitcher-extension/plugins/ui/index.ts
+++ b/packages/blazwitcher-extension/plugins/ui/index.ts
@@ -1,2 +1,3 @@
 export { RenderPluginItem, usePluginClickItem } from './render-item'
+export { formatFontFamily, renderFontItem, renderFontOption } from './render-font'
 export { SettingPanels } from './setting-panels'

--- a/packages/blazwitcher-extension/plugins/ui/render-font.tsx
+++ b/packages/blazwitcher-extension/plugins/ui/render-font.tsx
@@ -1,0 +1,29 @@
+import type { FontOption } from '~shared/types'
+
+export function formatFontFamily(fontName: string) {
+	return fontName.includes(' ') ? `"${fontName}", monospace` : `${fontName}, monospace`
+}
+
+export function renderFontItem(item: FontOption) {
+	const fontName = item.value
+	return (
+		<div style={{ fontFamily: fontName ? formatFontFamily(fontName) : 'inherit', fontSize: '14px' }}>
+			{item.label}
+		</div>
+	)
+}
+
+export function renderFontOption(item: FontOption) {
+	const fontName = item.value
+	return (
+		<div
+			style={{
+				fontFamily: fontName ? formatFontFamily(fontName) : 'inherit',
+				fontSize: '14px',
+				padding: '4px 0',
+			}}
+		>
+			{item.label}
+		</div>
+	)
+}

--- a/packages/blazwitcher-extension/plugins/ui/setting-panels/appearance.tsx
+++ b/packages/blazwitcher-extension/plugins/ui/setting-panels/appearance.tsx
@@ -1,15 +1,7 @@
-import {
-	IconComponent,
-	IconDesktop,
-	IconExpand,
-	IconInfoCircle,
-	IconLanguage,
-	IconMoon,
-	IconRefresh,
-	IconSun,
-	IconTerminal,
-} from '@douyinfe/semi-icons'
-import { Button, Card, InputNumber, Radio, RadioGroup, Tooltip } from '@douyinfe/semi-ui'
+import { IconComponent, IconDesktop, IconExpand, IconFont, IconInfoCircle, IconLanguage, IconMoon, IconRefresh, IconSun, IconTerminal } from '@douyinfe/semi-icons'
+import { Button, Card, InputNumber, Radio, RadioGroup, Select, Tooltip } from '@douyinfe/semi-ui'
+import { formatFontFamily } from '~plugins/ui'
+import type { FontOption } from '~shared/types'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import styled from 'styled-components'
 import {
@@ -20,8 +12,9 @@ import {
 	SEARCH_WINDOW_WIDTH,
 	type ThemeColor,
 } from '~shared/constants'
-import { i18nAtom, languageAtom, restoreAppearanceSettingsAtom, themeAtom } from '~sidepanel/atom'
+import { fontFamilyAtom, i18nAtom, languageAtom, restoreAppearanceSettingsAtom, themeAtom } from '~sidepanel/atom'
 import { debugAtom, displayModeAtom, heightAtom, widthAtom } from '~sidepanel/atom/windowAtom'
+import useFontOptions from '~sidepanel/hooks/useFontOptions'
 
 const Container = styled.div`
   display: flex;
@@ -80,6 +73,8 @@ export const AppearancePanel: React.FC = () => {
 	const [iframeHeight, setIframeHeight] = useAtom(heightAtom)
 	const [debugMode, setDebugMode] = useAtom(debugAtom)
 	const resetConfig = useSetAtom(restoreAppearanceSettingsAtom)
+	const [fontFamily, setFontFamily] = useAtom(fontFamilyAtom)
+	const fontOptions = useFontOptions()
 
 	const handleChangeWidth = (value: number) => {
 		setIframeWidth(value)
@@ -182,6 +177,20 @@ export const AppearancePanel: React.FC = () => {
 							/>
 						</SizeInputWrapper>
 					</SizeInputContainer>
+				</div>
+
+				<div>
+					<Section>
+						<IconFont />
+						{i18n('fontFamily')}
+					</Section>
+					<Select
+						style={{ width: '100%' }}
+						value={fontFamily}
+						onChange={(value) => setFontFamily(value as string)}
+						filter
+						optionList={fontOptions}
+					/>
 				</div>
 
 				<div>

--- a/packages/blazwitcher-extension/plugins/ui/setting-panels/appearance.tsx
+++ b/packages/blazwitcher-extension/plugins/ui/setting-panels/appearance.tsx
@@ -1,7 +1,16 @@
-import { IconComponent, IconDesktop, IconExpand, IconFont, IconInfoCircle, IconLanguage, IconMoon, IconRefresh, IconSun, IconTerminal } from '@douyinfe/semi-icons'
+import {
+	IconComponent,
+	IconDesktop,
+	IconExpand,
+	IconFont,
+	IconInfoCircle,
+	IconLanguage,
+	IconMoon,
+	IconRefresh,
+	IconSun,
+	IconTerminal,
+} from '@douyinfe/semi-icons'
 import { Button, Card, InputNumber, Radio, RadioGroup, Select, Tooltip } from '@douyinfe/semi-ui'
-import { formatFontFamily } from '~plugins/ui'
-import type { FontOption } from '~shared/types'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import styled from 'styled-components'
 import {

--- a/packages/blazwitcher-extension/shared/constants.ts
+++ b/packages/blazwitcher-extension/shared/constants.ts
@@ -141,6 +141,7 @@ export const DEFAULT_STRICTNESS_COEFFICIENT = 0.6
 export const PAGE_STORAGE_LANGUAGE_KEY = 'language'
 export const PAGE_STORAGE_SHORTCUT_MAPPINGS = 'shortcut_mappings'
 export const PAGE_STORAGE_THEME_COLOR = 'theme_color'
+export const PAGE_STORAGE_FONT_FAMILY = 'font_family'
 export const PAGE_STORAGE_SEARCH_CONFIG = 'search_config'
 /** 仅本机，不参与云端同步 */
 export const PAGE_STORAGE_SHOW_UPDATE_NOTIFICATION = 'show_update_notification'

--- a/packages/blazwitcher-extension/shared/promisify.ts
+++ b/packages/blazwitcher-extension/shared/promisify.ts
@@ -82,6 +82,10 @@ export const getBookmarksById = promisifyChromeMethod<chrome.bookmarks.BookmarkT
 	chrome.bookmarks.get.bind(chrome.bookmarks.get)
 )
 
+export const getFontList = chrome.fontSettings?.getFontList
+	? promisifyChromeMethod<chrome.fontSettings.FontName[]>(chrome.fontSettings.getFontList.bind(chrome.fontSettings))
+	: () => Promise.resolve([])
+
 export const getTabGroupById = chrome.tabGroups?.get
 	? promisifyChromeMethod<chrome.tabGroups.TabGroup>(chrome.tabGroups.get.bind(chrome.tabGroups))
 	: () => Promise.resolve(undefined)

--- a/packages/blazwitcher-extension/shared/types.ts
+++ b/packages/blazwitcher-extension/shared/types.ts
@@ -201,3 +201,8 @@ export type PortMessage =
 	| { type: PortMessageType.HistoryChunk; data: ListItemType[] }
 	| { type: PortMessageType.BookmarkChunk; data: ListItemType[] }
 	| { type: PortMessageType.WindowDataList; data: WindowData[] }
+
+export interface FontOption {
+	label: string
+	value: string
+}

--- a/packages/blazwitcher-extension/sidepanel/atom/index.ts
+++ b/packages/blazwitcher-extension/sidepanel/atom/index.ts
@@ -25,12 +25,9 @@ export const themeAtom = atomWithStorage<ThemeColor>(
 	{ getOnInit: true }
 )
 
-export const fontFamilyAtom = atomWithStorage<string>(
-	PAGE_STORAGE_FONT_FAMILY,
-	'',
-	createSyncStorage<string>(),
-	{ getOnInit: true }
-)
+export const fontFamilyAtom = atomWithStorage<string>(PAGE_STORAGE_FONT_FAMILY, '', createChromeSyncStorage<string>(), {
+	getOnInit: true,
+})
 
 export const activeItemAtom = atomWithReset<ListItemType | null>(null)
 export const originalListAtom = atomWithReset<ListItemType[]>([])

--- a/packages/blazwitcher-extension/sidepanel/atom/index.ts
+++ b/packages/blazwitcher-extension/sidepanel/atom/index.ts
@@ -1,6 +1,11 @@
 import { atom } from 'jotai'
 import { atomWithReset, atomWithStorage } from 'jotai/utils'
-import { PAGE_STORAGE_SHOW_UPDATE_NOTIFICATION, PAGE_STORAGE_THEME_COLOR, ThemeColor } from '~shared/constants'
+import {
+	PAGE_STORAGE_FONT_FAMILY,
+	PAGE_STORAGE_SHOW_UPDATE_NOTIFICATION,
+	PAGE_STORAGE_THEME_COLOR,
+	ThemeColor,
+} from '~shared/constants'
 import type { AiGroupingProgress, CommandPlugin, ListItemType, WindowData } from '~shared/types'
 import { createChromeSyncStorage } from './common'
 import { defaultLanguage, languageAtom } from './i18nAtom'
@@ -19,6 +24,14 @@ export const themeAtom = atomWithStorage<ThemeColor>(
 	createChromeSyncStorage<ThemeColor>(),
 	{ getOnInit: true }
 )
+
+export const fontFamilyAtom = atomWithStorage<string>(
+	PAGE_STORAGE_FONT_FAMILY,
+	'',
+	createSyncStorage<string>(),
+	{ getOnInit: true }
+)
+
 export const activeItemAtom = atomWithReset<ListItemType | null>(null)
 export const originalListAtom = atomWithReset<ListItemType[]>([])
 export const windowDataListAtom = atomWithReset<WindowData[]>([])
@@ -40,6 +53,7 @@ export const restoreAppearanceSettingsAtom = atom(
 	(_, set) => {
 		set(themeAtom, ThemeColor.System)
 		set(languageAtom, defaultLanguage)
+		set(fontFamilyAtom, '')
 		set(restoreWindowConfigAtom)
 	}
 )

--- a/packages/blazwitcher-extension/sidepanel/hooks/useFontOptions.tsx
+++ b/packages/blazwitcher-extension/sidepanel/hooks/useFontOptions.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { getFontList } from '~shared/promisify'
+import type { FontOption } from '~shared/types'
+import useI18n from './useI18n'
+
+export default function useFontOptions() {
+	const i18n = useI18n()
+	const [fontOptions, setFontOptions] = useState<FontOption[]>([])
+
+	useEffect(() => {
+		const fetchFonts = async () => {
+			const options = [
+				{ label: i18n('fontDefault'), value: '' },
+				{ label: i18n('fontSystem'), value: 'system-ui' },
+			]
+
+			try {
+				// Use Chrome Extension API to get system fonts - this won't trigger a permission prompt blur
+				const fonts = await getFontList()
+				if (fonts.length > 0) {
+					const systemFonts = fonts
+						.map((f) => ({ label: f.displayName, value: f.fontId }))
+						.sort((a, b) => a.label.localeCompare(b.label))
+
+					setFontOptions([...options, ...systemFonts])
+				} else {
+					setFontOptions(options)
+				}
+			} catch (e) {
+				console.error('Failed to get font list:', e)
+				setFontOptions(options)
+			}
+		}
+		fetchFonts()
+	}, [i18n])
+
+	return fontOptions
+}

--- a/packages/blazwitcher-extension/sidepanel/hooks/useTheme.ts
+++ b/packages/blazwitcher-extension/sidepanel/hooks/useTheme.ts
@@ -1,8 +1,9 @@
 import { useAtomValue } from 'jotai'
 import { useEffect, useMemo } from 'react'
+import { formatFontFamily } from '~plugins/ui'
 import { TabGroupColorMap } from '~shared/constants'
 import { isDarkMode } from '~shared/utils'
-import { themeAtom } from '~sidepanel/atom'
+import { fontFamilyAtom, themeAtom } from '~sidepanel/atom'
 
 export const setThemeClass = (isDark: boolean) => {
 	const body = document.body
@@ -17,13 +18,27 @@ export const setThemeClass = (isDark: boolean) => {
 	}
 }
 
+export const setFontFamily = (fontFamily: string) => {
+	const body = document.body
+	if (!fontFamily) {
+		body.style.removeProperty('--font-family')
+		return
+	}
+	body.style.setProperty('--font-family', formatFontFamily(fontFamily))
+}
+
 export const useTheme = () => {
 	const themeColor = useAtomValue(themeAtom)
+	const fontFamily = useAtomValue(fontFamilyAtom)
 
 	useEffect(() => {
 		// theme 已由 themeAtom 写入 chrome.storage.sync，无需在此重复写入；getWindowConfig 从 sync 读取
 		setThemeClass(isDarkMode(themeColor))
 	}, [themeColor])
+
+	useEffect(() => {
+		setFontFamily(fontFamily)
+	}, [fontFamily])
 }
 
 export const useColorMap = () => {

--- a/packages/blazwitcher-extension/sidepanel/sidepanel.css
+++ b/packages/blazwitcher-extension/sidepanel/sidepanel.css
@@ -2,7 +2,7 @@
 
 * {
 	box-sizing: border-box;
-	font-family: "SourceCodePro", monospace !important;
+	font-family: var(--font-family) !important;
 }
 html,
 body {
@@ -13,7 +13,7 @@ body {
 	padding: 0;
 }
 @font-face {
-	font-family: "SourceCodePro", monospace;
+	font-family: "SourceCodePro";
 	src: url("data-base64:~assets/SourceCodePro.ttf") format("ttf");
 }
 

--- a/packages/blazwitcher-extension/sidepanel/skin.css
+++ b/packages/blazwitcher-extension/sidepanel/skin.css
@@ -1,4 +1,5 @@
 html {
+	--font-family: "SourceCodePro", monospace;
 	--color-neutral-1: #171717;
 	--color-neutral-2: #262626;
 	--color-neutral-3: #404040;


### PR DESCRIPTION
issue #118 

仅在windows进行测试通过，添加了一个选择框。可选：软件默认、系统默认、系统已安装字体

不知道如何做字体选项预览

<img width="744" height="497" alt="Screenshot_2026-04-01_07-28-29" src="https://github.com/user-attachments/assets/02636813-6032-4045-b649-be2c054970e2" />
