### PR TITLE
fix(blazwitcher-extension): 🐛 correct start shortcut display parsing

### DIFF
--- a/.changeset/clever-keys-work.md
+++ b/.changeset/clever-keys-work.md
@@ -1,0 +1,6 @@
+---
+"blazwitcher": patch
+---
+
+fix: correct extension startup shortcut display formatting in keyboard settings on Windows
+fix: 修复 Windows 下键盘设置页扩展启动快捷键显示格式错误的问题

--- a/packages/blazwitcher-extension/plugins/ui/setting-panels/keyboard.tsx
+++ b/packages/blazwitcher-extension/plugins/ui/setting-panels/keyboard.tsx
@@ -169,7 +169,13 @@ export const KeyboardPanel: React.FC = () => {
 	useEffect(() => {
 		const fetchStartExtensionShortcut = async () => {
 			const shortcut = await getExecuteActionShortcuts()
-			setStartExtensionShortcut(shortcut?.split('').join(' + ') || '')
+			setStartExtensionShortcut(
+				shortcut
+					?.split('+')
+					.map((key) => key.trim())
+					.filter(Boolean)
+					.join(' + ') || ''
+			)
 		}
 		fetchStartExtensionShortcut()
 	}, [])


### PR DESCRIPTION
很小的修改

<img width="245" height="181" alt="image" src="https://github.com/user-attachments/assets/c84fdbb1-ca93-4ec5-afdc-cd4f8bc7e9b2" />
