### PR TITLE
chore: upgrade text-search-engine from 1.5.0 to 1.5.3

### DIFF
--- a/.changeset/smooth-pans-sin.md
+++ b/.changeset/smooth-pans-sin.md
@@ -1,0 +1,7 @@
+---
+"blazwitcher": patch
+---
+
+chore: upgrade text-search-engine from 1.5.0 to 1.5.3
+chore: 升级 text-search-engine 从 1.5.0 到 1.5.3
+  

--- a/packages/blazwitcher-extension/package.json
+++ b/packages/blazwitcher-extension/package.json
@@ -32,7 +32,7 @@
 		"react-dom": "18.2.0",
 		"rxjs": "8.0.0-alpha.14",
 		"styled-components": "^6.1.11",
-		"text-search-engine": "1.5.0"
+		"text-search-engine": "1.5.3"
 	},
 	"devDependencies": {
 		"@babel/parser": "^7.26.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^6.1.11
         version: 6.1.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       text-search-engine:
-        specifier: 1.5.0
-        version: 1.5.0(react@18.2.0)
+        specifier: 1.5.3
+        version: 1.5.3(react@18.2.0)
     devDependencies:
       '@babel/parser':
         specifier: ^7.26.3
@@ -8133,8 +8133,8 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
-  text-search-engine@1.5.0:
-    resolution: {integrity: sha512-/yq6VOv9Dd7vBVUk0DO/9z4UN6RlFV050qfy91f2EAn8d7um67+4NA1pbQ4D3lVrV0zV5jOT97UAZimxxWXa5w==}
+  text-search-engine@1.5.3:
+    resolution: {integrity: sha512-xvHne0XJlBZ1i4edxdYwbMRAyYKiGDdnPnVW3ISBhKsAwH4Moqyl0C8NAT5af5TXzMdAAb5jkwY7tk8Xzch9bw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -18012,7 +18012,7 @@ snapshots:
     dependencies:
       b4a: 1.6.7
 
-  text-search-engine@1.5.0(react@18.2.0):
+  text-search-engine@1.5.3(react@18.2.0):
     dependencies:
       react: 18.2.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,4 @@ allowBuilds:
   unrs-resolver: true
 minimumReleaseAgeExclude:
   - 'changesets-toolkit@0.1.0-beta.0 || 0.1.0'
+  - text-search-engine@1.5.3


### PR DESCRIPTION
## Summary
- Upgrade `text-search-engine` dependency from 1.5.0 to 1.5.3 in blazwitcher-extension

## Test plan
- [ ] Run `pnpm dev` to verify extension loads correctly
- [ ] Test fuzzy search functionality with Chinese/Pinyin input
- [ ] Run `pnpm --filter blazwitcher test` to verify all tests pass